### PR TITLE
Update babel-plugin-emotion to 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## master
 
+## 0.2.3
+* Babel Plugin Emotion update to 9.0.1
+
 ## 0.2.2
 
 * Added canvas and jest-image-snapshot

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quiq-scripts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Toolbox for creating front-end apps at quiq",
   "main": "src/index.js",
   "scripts": {
@@ -12,7 +12,7 @@
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.0.3",
     "babel-jest": "^22.4.0",
-    "babel-plugin-emotion": "^8.0.12",
+    "babel-plugin-emotion": "^9.0.1",
     "babel-plugin-react-intl": "^2.3.1",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",


### PR DESCRIPTION
The new version of emotion allows for labels to be added to  `css` and `styled.*` calls. The newest version of babel-plugin-emotion allows for these labels to be auto generated based on the variable names used.